### PR TITLE
Build non-fingerprinted CSS file copies on deploy

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -227,6 +227,12 @@ fi
 status "Building Ember CLI application $build_env distribution"
 $build_dir/node_modules/ember-cli/bin/ember build --environment $build_env | indent
 
+# For pages that rely on CSS but don't track fingerprinting
+status "Making non-fingerprinted copies of assets for distribution"
+for file in $build_dir/dist/assets/*.css; do
+  cp -a $file ${file%%-*}.css
+done
+
 if test -f $build_dir/hooks/after_hook.sh; then
   status "After hook detected. Running..."
   source $build_dir/hooks/after_hook.sh


### PR DESCRIPTION
When static pages share the same CSS as the Ember application, we don't
have a straightforward way to ensure that they load the same CSS without
a flicker or delay. broccoli-asset-rev fingerprints our assets on each
deploy, making it difficult for the static pages to know which CSS file
to download.

One solution is to use broccoli's assetMap, but this solution requires
JavaScript to load CSS, which makes our pages that use the
implementation look incorrect as the CSS loads after JavaScript files
and other assets have loaded.

The solution here is cribbed from the Ruby `sprockets-redirect` gem. On
deploy, we make a non-fingerprinted copy of each CSS file, allowing
permitted pages to request the latest CSS with a consistent canonical
name without knowledge of the fingerprint.